### PR TITLE
Support branch names in github dependencies

### DIFF
--- a/tests/examples-projects/github-dependency-branch/default.nix
+++ b/tests/examples-projects/github-dependency-branch/default.nix
@@ -1,0 +1,10 @@
+{ pkgs ? import ../../../nix { } }:
+
+pkgs.npmlock2nix.node_modules {
+  src = ./.;
+  packageJson = ./package.json;
+  packageLockJson = ./package-lock.json;
+  githubSourceHashMap = {
+    tmcw.leftpad.db1442a0556c2b133627ffebf455a78a1ced64b9 = "1zyy1nxbby4wcl30rc8fsis1c3f7nafavnwd3qi4bg0x00gxjdnh";
+  };
+}

--- a/tests/examples-projects/github-dependency-branch/package-lock.json
+++ b/tests/examples-projects/github-dependency-branch/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "github-dependency",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "leftpad": {
+      "version": "github:tmcw/leftpad#db1442a0556c2b133627ffebf455a78a1ced64b9",
+      "from": "github:tmcw/leftpad#v0.0.1"
+    }
+  }
+}

--- a/tests/examples-projects/github-dependency-branch/package.json
+++ b/tests/examples-projects/github-dependency-branch/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "github-dependency",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "leftpad": "github:tmcw/leftpad#v0.0.1"
+  }
+}

--- a/tests/patch-packagefile.nix
+++ b/tests/patch-packagefile.nix
@@ -5,27 +5,15 @@ let
 in
 (testLib.runTests {
   testTurnsGitHubRefsToWildcards = {
-    expr =
-      let
-        leftpad = (npmlock2nix.internal.patchPackagefile noGithubHashes ./examples-projects/github-dependency/package.json).dependencies.leftpad;
-      in
-      leftpad == "*";
-    expected = true;
+    expr = (npmlock2nix.internal.patchPackagefile noGithubHashes ./examples-projects/github-dependency/package.json).dependencies.leftpad;
+    expected = "*";
   };
   testHandlesBranches = {
-    expr =
-      let
-        leftpad = (npmlock2nix.internal.patchPackagefile noGithubHashes ./examples-projects/github-dependency-branch/package.json).dependencies.leftpad;
-      in
-      leftpad == "*";
-    expected = true;
+    expr = (npmlock2nix.internal.patchPackagefile noGithubHashes ./examples-projects/github-dependency-branch/package.json).dependencies.leftpad;
+    expected = "*";
   };
   testHandlesDevDependencies = {
-    expr =
-      let
-        leftpad = (npmlock2nix.internal.patchPackagefile noGithubHashes ./examples-projects/github-dev-dependency/package.json).devDependencies.leftpad;
-      in
-      leftpad == "*";
-    expected = true;
+    expr = (npmlock2nix.internal.patchPackagefile noGithubHashes ./examples-projects/github-dev-dependency/package.json).devDependencies.leftpad;
+    expected = "*";
   };
 })

--- a/tests/patch-packagefile.nix
+++ b/tests/patch-packagefile.nix
@@ -4,12 +4,20 @@ let
   i = npmlock2nix.internal;
 in
 (testLib.runTests {
-  testTurnsGitHubRefsToStorePaths = {
+  testTurnsGitHubRefsToWildcards = {
     expr =
       let
         leftpad = (npmlock2nix.internal.patchPackagefile noGithubHashes ./examples-projects/github-dependency/package.json).dependencies.leftpad;
       in
-      lib.hasPrefix ("file://" + builtins.storeDir) leftpad;
+      leftpad == "*";
+    expected = true;
+  };
+  testHandlesBranches = {
+    expr =
+      let
+        leftpad = (npmlock2nix.internal.patchPackagefile noGithubHashes ./examples-projects/github-dependency-branch/package.json).dependencies.leftpad;
+      in
+      leftpad == "*";
     expected = true;
   };
   testHandlesDevDependencies = {
@@ -17,7 +25,7 @@ in
       let
         leftpad = (npmlock2nix.internal.patchPackagefile noGithubHashes ./examples-projects/github-dev-dependency/package.json).devDependencies.leftpad;
       in
-      lib.hasPrefix ("file://" + builtins.storeDir) leftpad;
+      leftpad == "*";
     expected = true;
   };
 })


### PR DESCRIPTION
This allows to use dependency versions of the form org/repo#branch
where branch

This should fix #90 