### PR TITLE
add lockfilePostprocess

### DIFF
--- a/internal.nix
+++ b/internal.nix
@@ -301,7 +301,7 @@ rec {
       assert (builtins.typeOf preInstallLinks != "set") ->
         throw "`preInstallLinks` must be an attributeset of attributesets";
       let
-        cleanArgs = builtins.removeAttrs args [ "src" "packageJson" "packageLockJson" "buildInputs" "nativeBuildInputs" "nodejs" "preBuild" "postBuild" "preInstallLinks" "githubSourceHashMap" ];
+        cleanArgs = builtins.removeAttrs args [ "src" "packageJson" "packageLockJson" "buildInputs" "nativeBuildInputs" "nodejs" "preBuild" "postBuild" "preInstallLinks" "githubSourceHashMap" "lockfilePostprocess" ];
         lockfile = lockfilePostprocess (readLockfile packageLockJson);
 
         preinstall_node_modules = writeTextFile {

--- a/internal.nix
+++ b/internal.nix
@@ -295,13 +295,14 @@ rec {
     , preInstallLinks ? { } # set that describes which files should be linked in a specific packages folder
     , githubSourceHashMap ? { }
     , passthru ? { }
+    , lockfilePostprocess ? x:x
     , ...
     }@args:
       assert (builtins.typeOf preInstallLinks != "set") ->
         throw "`preInstallLinks` must be an attributeset of attributesets";
       let
         cleanArgs = builtins.removeAttrs args [ "src" "packageJson" "packageLockJson" "buildInputs" "nativeBuildInputs" "nodejs" "preBuild" "postBuild" "preInstallLinks" "githubSourceHashMap" ];
-        lockfile = readLockfile packageLockJson;
+        lockfile = lockfilePostprocess (readLockfile packageLockJson);
 
         preinstall_node_modules = writeTextFile {
           name = "prepare";

--- a/internal.nix
+++ b/internal.nix
@@ -295,7 +295,7 @@ rec {
     , preInstallLinks ? { } # set that describes which files should be linked in a specific packages folder
     , githubSourceHashMap ? { }
     , passthru ? { }
-    , lockfilePostprocess ? x:x
+    , lockfilePostprocess ? x: x
     , ...
     }@args:
       assert (builtins.typeOf preInstallLinks != "set") ->


### PR DESCRIPTION
allow to postprocess the lockfile data

for example manually set the package version

```nix
npmlock2nix.build rec {
  src = "...";
  node_modules_attrs = {
    lockfilePostprocess = lockfileSet: (lockfileSet // { version = "1.2.3"; });
  };
}
```

some package-lock.json files have no `version` field,
but npmlock2nix requires a version: `error: attribute 'version' missing`

similar issue: https://github.com/svanderburg/node2nix/issues/257

