### PR TITLE
fix npm output: disable live progress

### DIFF
--- a/internal.nix
+++ b/internal.nix
@@ -373,7 +373,7 @@ rec {
           declare -pf > $TMP/preinstall-env
           ln -s ${preinstall_node_modules}/node_modules/.hooks/prepare node_modules/.hooks/preinstall
           export HOME=.
-          npm install --offline --nodedir=${nodeSource nodejs}
+          npm install --offline --nodedir=${nodeSource nodejs} --no-progress
           test -d node_modules/.bin && patchShebangs node_modules/.bin
           rm -rf node_modules/.hooks
           runHook postBuild


### PR DESCRIPTION
remove scrambled output from `npm install`

progress is enabled by default
instead of `--no-progress`, we could also use `npm config set progress=false`

for debugging, we could use `--verbose` or `npm config set verbose=true`
but this is too verbose for normal use

the root cause for the scrambled output is probably a buffer issue
so that `\r` is parsed wrong

before

```
> aws4@1.11.0 preinstall /build/node_modules/aws4
> /build/node_modules/.hooks/preinstall
        ......] \ postinstall:readable-stream: info lifecycle readable-str0m

> @nodegui/nodegui@0.30.2 postinstall /build/node_modules/@nodegui/nodegui
> cross-env npm run setupqt && (node ./scripts/skip.js || npm run build:addon)

sh: /build/node_modules/.bin/cross-env: /usr/bin/env: bad interpreter: No such file or directory
npm ERR! code ELIFECYCLEifecycle @nodegui/nodegui@0.30.2~post[0m
npm ERR! errno 126
```

after

```
> aws4@1.11.0 preinstall /build/node_modules/aws4
> /build/node_modules/.hooks/preinstall

> @nodegui/nodegui@0.30.2 postinstall /build/node_modules/@nodegui/nodegui
> cross-env npm run setupqt && (node ./scripts/skip.js || npm run build:addon)

sh: /build/node_modules/.bin/cross-env: /usr/bin/env: bad interpreter: No such file or directory
npm ERR! code ELIFECYCLE
npm ERR! errno 126
```