### PR TITLE
Parameterize the command that install dependencies

### DIFF
--- a/API.md
+++ b/API.md
@@ -14,6 +14,7 @@ The `node_modules` function takes an attribute set with the following attributes
 - **packageJson** *(default `src+"/package.json"`)*: Path to `package.json`
 - **packageLockJson** *(default `src+"/package-lock.json"`)*: Path to `package-lock.json`
 - **nodejs** *(default `nixpkgs.nodejs`, which is the Active LTS version)*: Node.js derivation to use
+- **npmCmd** *(default `npm install --offline`)*: npm command to install dependencies
 - **preInstallLinks** *(default `{}`)*: Map of symlinks to create inside npm dependencies in the `node_modules` output (See [Concepts](#concepts) for details).
 - **githubSourceHashMap** *(default `{}`)*: Dependency hashes for evaluation in restricted mode (See [Concepts](#concepts) for details).
 

--- a/internal.nix
+++ b/internal.nix
@@ -290,6 +290,7 @@ rec {
     , buildInputs ? [ ]
     , nativeBuildInputs ? [ ]
     , nodejs ? default_nodejs
+    , npmCmd ? "npm install --offline"
     , preBuild ? ""
     , postBuild ? ""
     , preInstallLinks ? { } # set that describes which files should be linked in a specific packages folder
@@ -373,7 +374,7 @@ rec {
           declare -pf > $TMP/preinstall-env
           ln -s ${preinstall_node_modules}/node_modules/.hooks/prepare node_modules/.hooks/preinstall
           export HOME=.
-          npm install --offline --nodedir=${nodeSource nodejs}
+          ${npmCmd} --nodedir=${nodeSource nodejs}
           test -d node_modules/.bin && patchShebangs node_modules/.bin
           rm -rf node_modules/.hooks
           runHook postBuild


### PR DESCRIPTION
Basically I want to be able to pass the `--ignore-scripts` flag. Normally just parameterizing npm flags would be better but one might want to use `npm ci` instead of `npm install`. One possibility is to replace `npm install` with `npm ci`, hard code the latter and take the flags with a parameter like `npmFlags`.

I also left `--nodedir=${nodeSource nodejs}` hardcoded since it is not possible to pass it otherwise since `nodeSource` is an internal function.