### PR TITLE
Fix #113

### DIFF
--- a/internal.nix
+++ b/internal.nix
@@ -379,7 +379,7 @@ rec {
           runHook postBuild
         '';
         installPhase = ''
-          mkdir -p "$out"
+          mkdir "$out"
 
           if test -d node_modules; then
             if [ $(ls -1 node_modules | wc -l) -gt 0 ] || [ -e node_modules/.bin ]; then

--- a/internal.nix
+++ b/internal.nix
@@ -379,7 +379,7 @@ rec {
           runHook postBuild
         '';
         installPhase = ''
-          mkdir $out
+          mkdir -p "$out"
 
           if test -d node_modules; then
             if [ $(ls -1 node_modules | wc -l) -gt 0 ] || [ -e node_modules/.bin ]; then


### PR DESCRIPTION
Use double quote to prevent globbing and word-splitting. I am able to get `$out` with `declare -xp`, but the path cannot be echoed/mkdired.

The out path I have with my derivation is `declare -x out="/nix/store/nz8yczsvwi1hxnvppyzwc9nn06acvdb0-?prettier?plugin-pug-1.16.7"`, properly because of the `?` there.

Check full explanation for shellcheck error here: https://github.com/koalaman/shellcheck/wiki/SC2086