### PR TITLE
resolve fetchgit issue with nix 2.4

### DIFF
--- a/internal.nix
+++ b/internal.nix
@@ -67,7 +67,8 @@ rec {
             } else
           builtins.fetchGit {
             url = "https://github.com/${org}/${repo}";
-            inherit rev ref;
+            inherit rev;
+            allRefs = true;
           };
     in
     runCommand

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -17,7 +17,11 @@ let
       pkgs.fetchzip { inherit (spec) url sha256; };
 
   fetch_git = spec:
-    builtins.fetchGit { url = spec.repo; inherit (spec) rev ref; };
+  builtins.fetchGit { 
+    url = spec.repo;
+    inherit (spec) rev;
+    allRefs = true;
+  };
 
   fetch_builtin-tarball = spec:
     builtins.trace


### PR DESCRIPTION
Adds `allRefs = true;` to the invocation of fetchGit
as opposed to repassing the commit hash as the ref, which
fails with nix version >=2.4
Fixes #91