### PR TITLE
Use _ instead of ? as fall back character

### DIFF
--- a/internal.nix
+++ b/internal.nix
@@ -26,12 +26,12 @@ rec {
     "0" <= c && c <= "9" ||
     "a" <= c && c <= "z" ||
     "A" <= c && c <= "Z" ||
-    c == "+" || c == "-" || c == "." || c == "_" || c == "?" || c == "=";
+    c == "+" || c == "-" || c == "." || c == "_" || c == "=";
 
   # Description: Converts a npm package name to something that is compatible with nix
   # Type: String -> String
   makeValidDrvName = str:
-    lib.stringAsChars (c: if isValidDrvNameChar c then c else "?") str;
+    lib.stringAsChars (c: if isValidDrvNameChar c then c else "_") str;
 
   # Description: Takes a string of the format "github:org/repo#revision" and returns
   # an attribute set { org, repo, rev }

--- a/tests/sanitize-package-names.nix
+++ b/tests/sanitize-package-names.nix
@@ -6,7 +6,7 @@ testLib.runTests (
   ({
     # Using only a-zA-Z0-9 and a few selected special chars is allowed.
     testIsValidDrvNameCharHappyPath = {
-      expr = i.isValidDrvNameChar "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890_-.?=";
+      expr = i.isValidDrvNameChar "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890_-.=";
       expected = true;
     };
 
@@ -18,7 +18,7 @@ testLib.runTests (
     #  expected: false
     #       got: true
     let
-      cases = [ "!" "%" "^" "/" "\\" "#" "*" "(" ")" "@" "\"" "'" ];
+      cases = [ "!" "%" "^" "/" "\\" "#" "*" "(" ")" "@" "\"" "'" "?" ];
       mkCase = case: { expr = i.isValidDrvNameChar case; expected = false; };
     in
     lib.mapAttrs' (key: value: lib.nameValuePair "testIsValidDrvNameCharRejects: \"${key}\"" value) (
@@ -29,8 +29,8 @@ testLib.runTests (
     # We map the test cases from a (input, output)-style attribute set into the test structure such that we will receive human-friendly error messages when the tests fail.
     let
       cases = {
-        "asdf-123.-?_" = "asdf-123.-?_";
-        "ABCDEF$!%^/\\#*()@-'" = "ABCDEF???????????-?";
+        "asdf-123.-_" = "asdf-123.-_";
+        "ABCDEF$!%^/\\#*()@-'?" = "ABCDEF___________-__";
       };
       mkCase = (input: expected: { inherit expected; expr = i.makeValidDrvName input; });
     in


### PR DESCRIPTION
This fixes #118 by **removing ? from the list of valid derivation name characters** and using an underscore `_` as a fallback characters instead. I updated the tests accordingly.
