### PR TITLE
create subfolder at top level of tarball from Github

### DIFF
--- a/internal.nix
+++ b/internal.nix
@@ -74,7 +74,9 @@ rec {
       name
       { } ''
       set +x
-      tar -C ${src} -czf $out ./
+      mkdir package
+      cp -R ${src}/. package
+      tar -czf $out package
     '';
 
   # Description: Turns a dependency with a from field of the format


### PR DESCRIPTION
create a package dir at top level of tarball from Github
to fix bug where npm install cannot resolve dependencies.
This fix resolves ENOTCACHED errors in the preinstall phase
caused by improperly structured tarballs.

Tarballs that npm can use, package contents should reside
in a subfolder inside the tarball (usually it is called package/).
npm strips one directory layer when installing the package
(an equivalent of tar x --strip-components=1 is run).

See https://docs.npmjs.com/cli/v7/commands/npm-install

This relates to issue #45.