### PR TITLE
Nix2.4 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,6 @@ jobs:
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
       - run: nix-shell --run "nixpkgs-fmt --check ."
       - name: Try latest stable Nix release
-        run:  nix-shell -Inixpkgs=nix -p nix --run ./test.sh
+        run:  nix-shell -I nixpkgs=nix -p nix --run ./test.sh
       - name: Try tests with nix 2.3
-        run:  nix-shell -Inixpkgs=nix -p nix_2_3 --run ./test.sh
+        run:  nix-shell -I nixpkgs=nix -p nix_2_3 --run ./test.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,7 @@ jobs:
           name: npmlock2nix
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
       - run: nix-shell --run "nixpkgs-fmt --check ."
-      - run: ./test.sh
+      - name: Try latest stable Nix release
+        run:  nix-shell -Inixpkgs=nix -p nix --run ./test.sh
+      - name: Try tests with nix 2.3
+        run:  nix-shell -Inixpkgs=nix -p nix_2_3 --run ./test.sh

--- a/internal.nix
+++ b/internal.nix
@@ -67,7 +67,8 @@ rec {
             } else
           builtins.fetchGit {
             url = "https://github.com/${org}/${repo}";
-            inherit rev ref;
+            inherit rev;
+            allRefs = true;
           };
     in
     runCommand

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,4 +1,8 @@
-{}:
+/*
+  We have to ignore additional parameters passed to us as Nix 2.4 is injecting `inNixShell` without checking if the called expression actually wants it
+  See: https://github.com/NixOS/nix/pull/5543
+*/
+{ ... }:
 let
   sources = import ./sources.nix;
 in

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "253aecf69ed7595aaefabde779aa6449195bebb7",
-        "sha256": "14szn1k345jfm47k6vcgbxprmw1v16n7mvyhcdl7jbjmcggjh4z7",
+        "rev": "c5ed8beb478a8ca035f033f659b60c89500a3034",
+        "sha256": "0i4dxvnz7myn90kfqv8l5nvsk1k6lgmhg1xfags2h5bazyb0rr4c",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/253aecf69ed7595aaefabde779aa6449195bebb7.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/c5ed8beb478a8ca035f033f659b60c89500a3034.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "smoke": {

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -17,7 +17,11 @@ let
       pkgs.fetchzip { inherit (spec) url sha256; };
 
   fetch_git = spec:
-    builtins.fetchGit { url = spec.repo; inherit (spec) rev ref; };
+  builtins.fetchGit { 
+    url = spec.repo;
+    inherit (spec) rev;
+    allRefs = true;
+  };
 
   fetch_builtin-tarball = spec:
     builtins.trace

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -17,11 +17,11 @@ let
       pkgs.fetchzip { inherit (spec) url sha256; };
 
   fetch_git = spec:
-  builtins.fetchGit { 
-    url = spec.repo;
-    inherit (spec) rev;
-    allRefs = true;
-  };
+    builtins.fetchGit {
+      url = spec.repo;
+      inherit (spec) rev;
+      allRefs = true;
+    };
 
   fetch_builtin-tarball = spec:
     builtins.trace

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -I nixpkgs=./nix -p nix -i bash
+#!nix-shell -I nixpkgs=./nix -i bash
 
 set -e
 


### PR DESCRIPTION
This fixes various little bits within the repo to support Nix 2.4. to a degree where our CI doesn't fail anymore.

As part of this I also changed the CI workflow to always run the `test.sh` against the latest stable nix release and Nix 2.3.