### PR TITLE
Install nix 2.3.16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ jobs:
       - uses: cachix/install-nix-action@v14
         with:
           nix_path: nixpkgs=channel:nixpkgs-unstable
+          install_url: https://releases.nixos.org/nix/nix-2.3.16/install
       - uses: cachix/cachix-action@v10
         with:
           name: npmlock2nix


### PR DESCRIPTION
More recent versions of Nix make backwards incompatible changes such as
https://github.com/NixOS/nix/pull/5543 and apparently no interest
in fixing this - So we'll stick to a 2.3 version of Nix for now.