### PR TITLE
lockfile v2

### DIFF
--- a/internal.nix
+++ b/internal.nix
@@ -423,7 +423,7 @@ rec {
           declare -pf > $TMP/preinstall-env
           ln -s ${preinstall_node_modules}/node_modules/.hooks/prepare node_modules/.hooks/preinstall
           export HOME=.
-          npm install --offline --nodedir=${nodeSource nodejs}
+          npm ${if lockfile.lockfileVersion > 1 then "ci" else "install"} --offline --nodedir=${nodeSource nodejs}
           test -d node_modules/.bin && patchShebangs node_modules/.bin
           rm -rf node_modules/.hooks
           runHook postBuild

--- a/test.sh
+++ b/test.sh
@@ -9,7 +9,7 @@ echo -e "Running unit tests\n"
 nix-build -A tests --no-build-output --no-out-link --show-trace
 
 echo -e "\n\nRunning integration tests\n"
-$(nix-build  -A tests.integration-tests --no-out-link --show-trace)
+nix-build  -A tests.integration-tests --no-out-link --show-trace
 
 echo -e "\n\nTest githubSourceHashMap in restricted mode\n"
 nix-build tests/examples-projects/github-dependency/default.nix --restrict-eval -I . --allowed-uris 'https://github.com/nixos/nixpkgs' --show-trace

--- a/tests/examples-projects/single-dependency-v2/package-lock.json
+++ b/tests/examples-projects/single-dependency-v2/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "single-dependency-v2",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "single-dependency-v2",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "leftpad": "0.0.1"
+      }
+    },
+    "node_modules/leftpad": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/leftpad/-/leftpad-0.0.1.tgz",
+      "integrity": "sha1-hrGk3k+s4YCsVFqD8VA1I9j+0RU=",
+      "deprecated": "Use the built-in String.padStart function instead"
+    }
+  },
+  "dependencies": {
+    "leftpad": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/leftpad/-/leftpad-0.0.1.tgz",
+      "integrity": "sha1-hrGk3k+s4YCsVFqD8VA1I9j+0RU="
+    }
+  }
+}

--- a/tests/examples-projects/single-dependency-v2/package.json
+++ b/tests/examples-projects/single-dependency-v2/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "single-dependency-v2",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "leftpad": "0.0.1"
+  }
+}

--- a/tests/examples-projects/single-dependency-v2/shell.nix
+++ b/tests/examples-projects/single-dependency-v2/shell.nix
@@ -1,0 +1,5 @@
+{ pkgs ? import ../../../nix { } }:
+pkgs.npmlock2nix.shell {
+  src = ./.;
+  nodejs = pkgs.nodejs-16_x;
+}

--- a/tests/integration-tests/default.nix
+++ b/tests/integration-tests/default.nix
@@ -1,8 +1,16 @@
-{ npmlock2nix, testLib, callPackage, libwebp, runCommandNoCC, python3 }:
+{ npmlock2nix, testLib, callPackage, libwebp, runCommandNoCC, python3, nodejs-16_x }:
 testLib.makeIntegrationTests {
   leftpad = {
     description = "Require a node dependency inside the shell environment";
     shell = npmlock2nix.shell { src = ../examples-projects/single-dependency; };
+    command = ''
+      node -e 'console.log(require("leftpad")(123, 7));'
+    '';
+    expected = "0000123\n";
+  };
+  leftpadV2 = {
+    description = "Handle a v2 npm lock file";
+    shell = npmlock2nix.shell { src = ../examples-projects/single-dependency-v2; nodejs = nodejs-16_x; };
     command = ''
       node -e 'console.log(require("leftpad")(123, 7));'
     '';


### PR DESCRIPTION
an ugly attempt at getting started with lockfile v2 support

patching shebangs probably doesn't work: npm install doesn't treat the lockfile as frozen and npm ci removes node_packages before fetching packages, and the hook with it

related to #140