### PR TITLE
Correct patched lockfile derivation name

### DIFF
--- a/internal.nix
+++ b/internal.nix
@@ -253,7 +253,7 @@ rec {
 
   # Description: Takes a Path to a lockfile and returns the patched version as file in the Nix store
   # Type: Fn -> Path -> Derivation
-  patchedLockfile = sourceHashFunc: file: writeText "packages-lock.json"
+  patchedLockfile = sourceHashFunc: file: writeText "package-lock.json"
     (builtins.toJSON (patchLockfile sourceHashFunc file));
 
   # Description: Turn a derivation (with name & src attribute) into a directory containing the unpacked sources

--- a/internal.nix
+++ b/internal.nix
@@ -308,13 +308,13 @@ rec {
   sourceHashFunc = githubSourceHashMap: spec:
     if spec.type == "github" then
       lib.attrByPath
-      [ spec.value.org spec.value.repo spec.value.rev ]
-      (
-        lib.traceSeq
-        "[npmlock2nix] warning: missing attr in githubSourceHashMap: ${spec.value.org}.${spec.value.repo}.${spec.value.rev}"
-        null
-      )
-      githubSourceHashMap
+        [ spec.value.org spec.value.repo spec.value.rev ]
+        (
+          lib.traceSeq
+            "[npmlock2nix] warning: missing attr in githubSourceHashMap: ${spec.value.org}.${spec.value.repo}.${spec.value.rev}"
+            null
+        )
+        githubSourceHashMap
     else
       throw "sourceHashFunc: spec.type '${spec.type}' is not supported. Supported types: 'github'";
 


### PR DESCRIPTION
The file is called package-lock.json, not packageS-lock.json. This can lead
to problems finding the file in nix store listings

Includes #148 to fix CI