### PR TITLE
Allow patching dependency sources

### DIFF
--- a/API.md
+++ b/API.md
@@ -16,6 +16,7 @@ The `node_modules` function takes an attribute set with the following attributes
 - **nodejs** *(default `nixpkgs.nodejs`, which is the Active LTS version)*: Node.js derivation to use
 - **preInstallLinks** *(default `{}`)*: Map of symlinks to create inside npm dependencies in the `node_modules` output (See [Concepts](#concepts) for details).
 - **githubSourceHashMap** *(default `{}`)*: Dependency hashes for evaluation in restricted mode (See [Concepts](#concepts) for details).
+- **sourceAttrs** *(default `{}`)*: Derivation attributes to apply to sources, allowing patching (See [Concepts](#concepts) for details)
 
 #### Notes
 - You may provide additional arguments accepted by `mkDerivation` all of which are going to be passed on.
@@ -111,6 +112,35 @@ npmlock2nix.build {
   src = ./.;
   node_modules_attrs = {
     buildInputs = [ pkgs.zlib ];
+  };
+}
+```
+
+### Source derivation attributes
+
+`node_modules` takes a `sourceAttrs` argument, which allows you to modify the source derivations of individual npm packages you depend on, mainly useful for adding Nix-specific fixes to packages. This could be used for patching interpreter or paths, or to replace vendored binaries with ones provided by Nix.
+
+The `sourceAttrs` argument expects an attribute set mapping npm package names to a function describing the modifications of that package. Each function receives an attribute set as an argument containing either a `version` attribute if the version is known, or a `github = { org, repo, rev, ref }` attribute if the package is fetched from GitHub. These values can be used to decide what the result of the function should be. The result of this function is passed to a `mkDerivation` call running mainly the [patch phase](https://nixos.org/manual/nixpkgs/stable/#ssec-patch-phase), meaning that [most `mkDerivation` arguments](https://nixos.org/manual/nixpkgs/stable/#chap-stdenv) can be returned from it. Of particular interest are `patches` and `postPatch`, in which `patchShebangs` can be called. Note that `patchShebangs` can only patch shebangs to binaries accessible in the derivation, which you can extend with `buildInputs`. For convenience, the correct version of `nodejs` is always included in `buildInputs`.
+
+```nix
+npmlock2nix.node_modules {
+  sourceMods = {
+    # sourceInfo either contains:
+    # - A version attribute
+    # - A github = { org, repo, rev, ref } attribute for GitHub sources
+    package-name = sourceInfo: {
+      buildInputs = [ somePackage ];
+      patches = [ somePatch ];
+      postPatch = ''
+        some script
+      '';
+      # ...
+    }
+
+    # Example
+    node-pre-gyp = sourceInfo: {
+      postPatch = "patchShebangs bin";
+    };
   };
 }
 ```

--- a/API.md
+++ b/API.md
@@ -16,7 +16,7 @@ The `node_modules` function takes an attribute set with the following attributes
 - **nodejs** *(default `nixpkgs.nodejs`, which is the Active LTS version)*: Node.js derivation to use
 - **preInstallLinks** *(default `{}`)*: Map of symlinks to create inside npm dependencies in the `node_modules` output (See [Concepts](#concepts) for details).
 - **githubSourceHashMap** *(default `{}`)*: Dependency hashes for evaluation in restricted mode (See [Concepts](#concepts) for details).
-- **sourceAttrs** *(default `{}`)*: Derivation attributes to apply to sources, allowing patching (See [Concepts](#concepts) for details)
+- **sourceOverrides** *(default `{}`)*: Derivation attributes to apply to sources, allowing patching (See the [source derivation overrides](#source-derivation-overrides) concept for details)
 
 #### Notes
 - You may provide additional arguments accepted by `mkDerivation` all of which are going to be passed on.
@@ -116,31 +116,31 @@ npmlock2nix.build {
 }
 ```
 
-### Source derivation attributes
+### Source derivation overrides
 
-`node_modules` takes a `sourceAttrs` argument, which allows you to modify the source derivations of individual npm packages you depend on, mainly useful for adding Nix-specific fixes to packages. This could be used for patching interpreter or paths, or to replace vendored binaries with ones provided by Nix.
+`node_modules` takes a `sourceOverrides` argument, which allows you to modify the source derivations of individual npm packages you depend on, mainly useful for adding Nix-specific fixes to packages. This could be used for patching interpreter or paths, or to replace vendored binaries with ones provided by Nix.
 
-The `sourceAttrs` argument expects an attribute set mapping npm package names to a function describing the modifications of that package. Each function receives an attribute set as an argument containing either a `version` attribute if the version is known, or a `github = { org, repo, rev, ref }` attribute if the package is fetched from GitHub. These values can be used to decide what the result of the function should be. The result of this function is passed to a `mkDerivation` call running mainly the [patch phase](https://nixos.org/manual/nixpkgs/stable/#ssec-patch-phase), meaning that [most `mkDerivation` arguments](https://nixos.org/manual/nixpkgs/stable/#chap-stdenv) can be returned from it. Of particular interest are `patches` and `postPatch`, in which `patchShebangs` can be called. Note that `patchShebangs` can only patch shebangs to binaries accessible in the derivation, which you can extend with `buildInputs`. For convenience, the correct version of `nodejs` is always included in `buildInputs`.
+The `sourceOverrides` argument expects an attribute set mapping npm package names to a function describing the modifications of that package. Each function receives an attribute set as a first argument, containing either a `version` attribute if the version is known, or a `github = { org, repo, rev, ref }` attribute if the package is fetched from GitHub. These values can be used to have different overrides depending on the version. The function receives another argument which is the derivation of the fetched source, which can be modified using `.overrideAttrs`. The fetched source mainly runs the [patch phase](https://nixos.org/manual/nixpkgs/stable/#ssec-patch-phase), so of particular interest are the `patches` and `postPatch` attributes, in which `patchShebangs` can be called. Note that `patchShebangs` can only patch shebangs to binaries accessible in the derivation, which you can extend with `buildInputs`. For convenience, the correct version of `nodejs` is always included in `buildInputs`.
 
 ```nix
 npmlock2nix.node_modules {
-  sourceMods = {
+  sourceOverrides = {
     # sourceInfo either contains:
     # - A version attribute
     # - A github = { org, repo, rev, ref } attribute for GitHub sources
-    package-name = sourceInfo: {
+    package-name = sourceInfo: drv: drv.overrideAttrs (old: {
       buildInputs = [ somePackage ];
       patches = [ somePatch ];
       postPatch = ''
         some script
       '';
       # ...
-    }
+    })
 
     # Example
-    node-pre-gyp = sourceInfo: {
+    node-pre-gyp = sourceInfo: drv: drv.overrideAttrs (old: {
       postPatch = "patchShebangs bin";
-    };
+    });
   };
 }
 ```

--- a/internal.nix
+++ b/internal.nix
@@ -209,8 +209,8 @@ rec {
     };
 
   # Description: Rewrite all the `github:` references to wildcards.
-  # Type: Fn -> Path -> Set
-  patchPackagefile = sourceHashFunc: file:
+  # Type: Path -> Set
+  patchPackagefile = file:
     assert (builtins.typeOf file != "path" && builtins.typeOf file != "string") ->
       throw "file ${toString file} must be a path or string";
     let
@@ -233,10 +233,10 @@ rec {
     content // { inherit devDependencies dependencies; };
 
   # Description: Takes a Path to a package file and returns the patched version as file in the Nix store
-  # Type: Fn -> Path -> Derivation
-  patchedPackagefile = sourceHashFunc: file: writeText "package.json"
+  # Type: Path -> Derivation
+  patchedPackagefile = file: writeText "package.json"
     (
-      builtins.toJSON (patchPackagefile sourceHashFunc file)
+      builtins.toJSON (patchPackagefile file)
     );
 
   # Description: Takes a Path to a lockfile and returns the patched version as file in the Nix store
@@ -389,7 +389,7 @@ rec {
 
         postPatch = ''
           ln -sf ${patchedLockfile (sourceHashFunc githubSourceHashMap) packageLockJson} package-lock.json
-          ln -sf ${patchedPackagefile (sourceHashFunc githubSourceHashMap) packageJson} package.json
+          ln -sf ${patchedPackagefile packageJson} package.json
         '';
 
         buildPhase = ''

--- a/tests/examples-projects/source-patching/package-lock.json
+++ b/tests/examples-projects/source-patching/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "source-patching",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "custom-hello-world": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/custom-hello-world/-/custom-hello-world-1.0.3.tgz",
+      "integrity": "sha512-Rinkq1q+uLmgbDLZRNZrlyeK3G9e+o0gbVy6r948kySbau0ymwOPNybu4iIkb4R1gE5aZsQUHgtfCg2oZ4zfbw=="
+    }
+  }
+}

--- a/tests/examples-projects/source-patching/package.json
+++ b/tests/examples-projects/source-patching/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "source-patching",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "custom-hello-world": "^1.0.0"
+  }
+}

--- a/tests/examples-projects/source-patching/shell.nix
+++ b/tests/examples-projects/source-patching/shell.nix
@@ -1,0 +1,25 @@
+{ npmlock2nix }:
+npmlock2nix.shell {
+  src = ./.;
+  node_modules_attrs = {
+    sourceAttrs = {
+      custom-hello-world = _: {
+        patches = builtins.toFile "custom-hello-world.patch" ''
+          diff --git a/lib/index.js b/lib/index.js
+          index 1f66513..64391a7 100644
+          --- a/lib/index.js
+          +++ b/lib/index.js
+          @@ -21,7 +21,7 @@ function generateHelloWorld({ comma, exclamation, lowercase }) {
+             if (comma)
+               helloWorldStr += ',';
+             
+          -  helloWorldStr += ' World';
+          +  helloWorldStr += ' Nix';
+           
+             if (exclamation)
+               helloWorldStr += '!';
+        '';
+      };
+    };
+  };
+}

--- a/tests/examples-projects/source-patching/shell.nix
+++ b/tests/examples-projects/source-patching/shell.nix
@@ -2,8 +2,8 @@
 npmlock2nix.shell {
   src = ./.;
   node_modules_attrs = {
-    sourceAttrs = {
-      custom-hello-world = _: {
+    sourceOverrides = {
+      custom-hello-world = sourceInfo: drv: drv.overrideAttrs (old: {
         patches = builtins.toFile "custom-hello-world.patch" ''
           diff --git a/lib/index.js b/lib/index.js
           index 1f66513..64391a7 100644
@@ -19,7 +19,7 @@ npmlock2nix.shell {
              if (exclamation)
                helloWorldStr += '!';
         '';
-      };
+      });
     };
   };
 }

--- a/tests/integration-tests/default.nix
+++ b/tests/integration-tests/default.nix
@@ -284,4 +284,13 @@ testLib.makeIntegrationTests {
       '';
     };
   };
+
+  source-patching = {
+    description = "Source patching works";
+    shell = callPackage ../examples-projects/source-patching/shell.nix { };
+    command = ''
+      node -e 'console.log(require("custom-hello-world")({}));'
+    '';
+    expected = "Hello Nix\n";
+  };
 }

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -10,7 +10,10 @@
   # Reads a given file (either drv, path or string) and returns it's sha256 hash
   hashFile = filename: builtins.hashString "sha256" (builtins.readFile filename);
 
-  noSourceOptions = { sourceHashFunc = _: null; };
+  noSourceOptions = {
+    sourceHashFunc = _: null;
+    nodejs = null;
+  };
 
   runTests = tests:
     let

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -10,7 +10,7 @@
   # Reads a given file (either drv, path or string) and returns it's sha256 hash
   hashFile = filename: builtins.hashString "sha256" (builtins.readFile filename);
 
-  noGithubHashes = (_: null);
+  noSourceOptions = { sourceHashFunc = _: null; };
 
   runTests = tests:
     let

--- a/tests/make-github-source.nix
+++ b/tests/make-github-source.nix
@@ -1,6 +1,6 @@
 { lib, npmlock2nix, testLib }:
 let
-  inherit (testLib) noGithubHashes;
+  inherit (testLib) noSourceOptions;
   i = npmlock2nix.internal;
 
   testDependency = {
@@ -12,7 +12,7 @@ in
   testSimpleCase = {
     expr =
       let
-        version = (i.makeGithubSource noGithubHashes "leftpad" testDependency).version;
+        version = (i.makeGithubSource noSourceOptions "leftpad" testDependency).version;
       in
       lib.hasPrefix "file:///nix/store" version;
     expected = true;
@@ -21,7 +21,7 @@ in
   testDropsFrom = {
     expr =
       let
-        dep = i.makeGithubSource noGithubHashes "leftpad" testDependency;
+        dep = i.makeGithubSource noSourceOptions "leftpad" testDependency;
       in
       dep ? from;
     expected = false;

--- a/tests/make-source.nix
+++ b/tests/make-source.nix
@@ -1,7 +1,7 @@
 { testLib, npmlock2nix }:
 let
   i = npmlock2nix.internal;
-  f = builtins.throw "Shouldn't be called";
+  f = { sourceHashFunc = builtins.throw "Shouldn't be called"; };
 in
 testLib.runTests {
   testMakeSourceRegular = {

--- a/tests/make-source.nix
+++ b/tests/make-source.nix
@@ -1,7 +1,10 @@
 { testLib, npmlock2nix }:
 let
   i = npmlock2nix.internal;
-  f = { sourceHashFunc = builtins.throw "Shouldn't be called"; };
+  f = {
+    sourceHashFunc = builtins.throw "Shouldn't be called";
+    nodejs = null;
+  };
 in
 testLib.runTests {
   testMakeSourceRegular = {

--- a/tests/patch-lockfile.nix
+++ b/tests/patch-lockfile.nix
@@ -1,13 +1,13 @@
 { npmlock2nix, testLib, lib }:
 let
-  inherit (testLib) noGithubHashes;
+  inherit (testLib) noSourceOptions;
 in
 testLib.runTests {
 
   testPatchDependencyHandlesGitHubRefsInRequires = {
     expr =
       let
-        libxmljsUrl = (npmlock2nix.internal.patchDependency noGithubHashes "test" {
+        libxmljsUrl = (npmlock2nix.internal.patchDependency noSourceOptions "test" {
           version = "github:tmcw/leftpad#db1442a0556c2b133627ffebf455a78a1ced64b9";
           from = "github:tmcw/leftpad#db1442a0556c2b133627ffebf455a78a1ced64b9";
           integrity = "sha512-8/UvHFG90J4O4QNRzb0jB5Ni1QuvuB7XFTLfDMQnCzAsFemF29VKnNGUESFFcSP/r5WWh/PMe0YRz90+3IqsUA==";
@@ -22,7 +22,7 @@ testLib.runTests {
   };
 
   testBundledDependenciesAreRetained = {
-    expr = npmlock2nix.internal.patchDependency noGithubHashes "test" {
+    expr = npmlock2nix.internal.patchDependency noSourceOptions "test" {
       bundled = true;
       integrity = "sha1-hrGk3k+s4YCsVFqD8VA1I9j+0RU=";
       something = "bar";
@@ -37,12 +37,12 @@ testLib.runTests {
   };
 
   testPatchLockfileWithoutDependencies = {
-    expr = (npmlock2nix.internal.patchLockfile noGithubHashes ./examples-projects/no-dependencies/package-lock.json).dependencies;
+    expr = (npmlock2nix.internal.patchLockfile noSourceOptions ./examples-projects/no-dependencies/package-lock.json).dependencies;
     expected = { };
   };
 
   testPatchDependencyDoesntDropAttributes = {
-    expr = npmlock2nix.internal.patchDependency noGithubHashes "test" {
+    expr = npmlock2nix.internal.patchDependency noSourceOptions "test" {
       a = 1;
       foo = "something";
       resolved = "https://examples.com/something.tgz";
@@ -59,7 +59,7 @@ testLib.runTests {
   };
 
   testPatchDependencyPatchesDependenciesRecursively = {
-    expr = npmlock2nix.internal.patchDependency noGithubHashes "test" {
+    expr = npmlock2nix.internal.patchDependency noSourceOptions "test" {
       a = 1;
       foo = "something";
       resolved = "https://examples.com/something.tgz";
@@ -85,7 +85,7 @@ testLib.runTests {
   testPatchLockfileTurnsUrlsIntoStorePaths = {
     expr =
       let
-        deps = (npmlock2nix.internal.patchLockfile noGithubHashes ./examples-projects/single-dependency/package-lock.json).dependencies;
+        deps = (npmlock2nix.internal.patchLockfile noSourceOptions ./examples-projects/single-dependency/package-lock.json).dependencies;
       in
       lib.count (dep: lib.hasPrefix "file:///nix/store/" dep.resolved) (lib.attrValues deps);
     expected = 1;
@@ -94,19 +94,19 @@ testLib.runTests {
   testPatchLockfileTurnsGitHubUrlsIntoStorePaths = {
     expr =
       let
-        leftpad = (npmlock2nix.internal.patchLockfile noGithubHashes ./examples-projects/github-dependency/package-lock.json).dependencies.leftpad;
+        leftpad = (npmlock2nix.internal.patchLockfile noSourceOptions ./examples-projects/github-dependency/package-lock.json).dependencies.leftpad;
       in
       lib.hasPrefix ("file://" + builtins.storeDir) leftpad.version;
     expected = true;
   };
 
   testConvertPatchedLockfileToJSON = {
-    expr = builtins.typeOf (builtins.toJSON (npmlock2nix.internal.patchLockfile noGithubHashes ./examples-projects/nested-dependencies/package-lock.json)) == "string";
+    expr = builtins.typeOf (builtins.toJSON (npmlock2nix.internal.patchLockfile noSourceOptions ./examples-projects/nested-dependencies/package-lock.json)) == "string";
     expected = true;
   };
 
   testPatchedLockFile = {
-    expr = testLib.hashFile (npmlock2nix.internal.patchedLockfile noGithubHashes ./examples-projects/nested-dependencies/package-lock.json);
+    expr = testLib.hashFile (npmlock2nix.internal.patchedLockfile noSourceOptions ./examples-projects/nested-dependencies/package-lock.json);
     expected = "980323c3a53d86ab6886f21882936cfe7c06ac633993f16431d79e3185084414";
   };
 

--- a/tests/patch-lockfile.nix
+++ b/tests/patch-lockfile.nix
@@ -7,7 +7,7 @@ testLib.runTests {
   testPatchDependencyHandlesGitHubRefsInRequires = {
     expr =
       let
-        libxmljsUrl = (npmlock2nix.internal.patchDependency noSourceOptions "test" {
+        libxmljsUrl = (npmlock2nix.internal.patchDependency [ ] noSourceOptions "test" {
           version = "github:tmcw/leftpad#db1442a0556c2b133627ffebf455a78a1ced64b9";
           from = "github:tmcw/leftpad#db1442a0556c2b133627ffebf455a78a1ced64b9";
           integrity = "sha512-8/UvHFG90J4O4QNRzb0jB5Ni1QuvuB7XFTLfDMQnCzAsFemF29VKnNGUESFFcSP/r5WWh/PMe0YRz90+3IqsUA==";
@@ -15,19 +15,19 @@ testLib.runTests {
             libxmljs = "github:znerol/libxmljs#0517e063347ea2532c9fdf38dc47878c628bf0ae";
           };
         }
-        ).requires.libxmljs;
+        ).result.requires.libxmljs;
       in
       lib.hasPrefix builtins.storeDir libxmljsUrl;
     expected = true;
   };
 
   testBundledDependenciesAreRetained = {
-    expr = npmlock2nix.internal.patchDependency noSourceOptions "test" {
+    expr = (npmlock2nix.internal.patchDependency [ ] noSourceOptions "test" {
       bundled = true;
       integrity = "sha1-hrGk3k+s4YCsVFqD8VA1I9j+0RU=";
       something = "bar";
       dependencies = { };
-    };
+    }).result;
     expected = {
       bundled = true;
       integrity = "sha1-hrGk3k+s4YCsVFqD8VA1I9j+0RU=";
@@ -37,18 +37,18 @@ testLib.runTests {
   };
 
   testPatchLockfileWithoutDependencies = {
-    expr = (npmlock2nix.internal.patchLockfile noSourceOptions ./examples-projects/no-dependencies/package-lock.json).dependencies;
+    expr = (npmlock2nix.internal.patchLockfile noSourceOptions ./examples-projects/no-dependencies/package-lock.json).result.dependencies;
     expected = { };
   };
 
   testPatchDependencyDoesntDropAttributes = {
-    expr = npmlock2nix.internal.patchDependency noSourceOptions "test" {
+    expr = (npmlock2nix.internal.patchDependency [ ] noSourceOptions "test" {
       a = 1;
       foo = "something";
       resolved = "https://examples.com/something.tgz";
       integrity = "sha1-00000000000000000000000+0RU=";
       dependencies = { };
-    };
+    }).result;
     expected = {
       a = 1;
       foo = "something";
@@ -59,7 +59,7 @@ testLib.runTests {
   };
 
   testPatchDependencyPatchesDependenciesRecursively = {
-    expr = npmlock2nix.internal.patchDependency noSourceOptions "test" {
+    expr = (npmlock2nix.internal.patchDependency [ ] noSourceOptions "test" {
       a = 1;
       foo = "something";
       resolved = "https://examples.com/something.tgz";
@@ -68,7 +68,7 @@ testLib.runTests {
         resolved = "https://examples.com/somethingelse.tgz";
         integrity = "sha1-00000000000000000000000+00U=";
       };
-    };
+    }).result;
 
     expected = {
       a = 1;
@@ -85,7 +85,7 @@ testLib.runTests {
   testPatchLockfileTurnsUrlsIntoStorePaths = {
     expr =
       let
-        deps = (npmlock2nix.internal.patchLockfile noSourceOptions ./examples-projects/single-dependency/package-lock.json).dependencies;
+        deps = (npmlock2nix.internal.patchLockfile noSourceOptions ./examples-projects/single-dependency/package-lock.json).result.dependencies;
       in
       lib.count (dep: lib.hasPrefix "file:///nix/store/" dep.resolved) (lib.attrValues deps);
     expected = 1;
@@ -94,19 +94,19 @@ testLib.runTests {
   testPatchLockfileTurnsGitHubUrlsIntoStorePaths = {
     expr =
       let
-        leftpad = (npmlock2nix.internal.patchLockfile noSourceOptions ./examples-projects/github-dependency/package-lock.json).dependencies.leftpad;
+        leftpad = (npmlock2nix.internal.patchLockfile noSourceOptions ./examples-projects/github-dependency/package-lock.json).result.dependencies.leftpad;
       in
       lib.hasPrefix ("file://" + builtins.storeDir) leftpad.version;
     expected = true;
   };
 
   testConvertPatchedLockfileToJSON = {
-    expr = builtins.typeOf (builtins.toJSON (npmlock2nix.internal.patchLockfile noSourceOptions ./examples-projects/nested-dependencies/package-lock.json)) == "string";
+    expr = builtins.typeOf (builtins.toJSON (npmlock2nix.internal.patchLockfile noSourceOptions ./examples-projects/nested-dependencies/package-lock.json).result) == "string";
     expected = true;
   };
 
   testPatchedLockFile = {
-    expr = testLib.hashFile (npmlock2nix.internal.patchedLockfile noSourceOptions ./examples-projects/nested-dependencies/package-lock.json);
+    expr = testLib.hashFile (npmlock2nix.internal.patchedLockfile noSourceOptions ./examples-projects/nested-dependencies/package-lock.json).result;
     expected = "980323c3a53d86ab6886f21882936cfe7c06ac633993f16431d79e3185084414";
   };
 

--- a/tests/patch-packagefile.nix
+++ b/tests/patch-packagefile.nix
@@ -1,19 +1,18 @@
 { lib, npmlock2nix, testLib }:
 let
-  inherit (testLib) noGithubHashes;
   i = npmlock2nix.internal;
 in
 (testLib.runTests {
   testTurnsGitHubRefsToWildcards = {
-    expr = (npmlock2nix.internal.patchPackagefile noGithubHashes ./examples-projects/github-dependency/package.json).dependencies.leftpad;
+    expr = (npmlock2nix.internal.patchPackagefile ./examples-projects/github-dependency/package.json).dependencies.leftpad;
     expected = "*";
   };
   testHandlesBranches = {
-    expr = (npmlock2nix.internal.patchPackagefile noGithubHashes ./examples-projects/github-dependency-branch/package.json).dependencies.leftpad;
+    expr = (npmlock2nix.internal.patchPackagefile ./examples-projects/github-dependency-branch/package.json).dependencies.leftpad;
     expected = "*";
   };
   testHandlesDevDependencies = {
-    expr = (npmlock2nix.internal.patchPackagefile noGithubHashes ./examples-projects/github-dev-dependency/package.json).devDependencies.leftpad;
+    expr = (npmlock2nix.internal.patchPackagefile ./examples-projects/github-dev-dependency/package.json).devDependencies.leftpad;
     expected = "*";
   };
 })


### PR DESCRIPTION
Adds support for patching dependency sources with `patches` and `postPatch` derivation attributes. This is a bit hacky, as patching any files requires recalculating the `integrity` value, which needs to be done at build-time. But it works, and I made sure to make the code resilient and commented.

This is a solution for https://github.com/nix-community/npmlock2nix/issues/110, as this allows doing `patchShebangs` on individual packages. `npmlock2nix` could also provide a predefined list of patches for individual packages for convenience in the future.