### PR TITLE
Authentication support

### DIFF
--- a/internal.nix
+++ b/internal.nix
@@ -209,8 +209,8 @@ rec {
     };
 
   # Description: Rewrite all the `github:` references to wildcards.
-  # Type: Fn -> Path -> Set
-  patchPackagefile = sourceHashFunc: file:
+  # Type: Path -> Set
+  patchPackagefile = file:
     assert (builtins.typeOf file != "path" && builtins.typeOf file != "string") ->
       throw "file ${toString file} must be a path or string";
     let
@@ -233,10 +233,10 @@ rec {
     content // { inherit devDependencies dependencies; };
 
   # Description: Takes a Path to a package file and returns the patched version as file in the Nix store
-  # Type: Fn -> Path -> Derivation
-  patchedPackagefile = sourceHashFunc: file: writeText "package.json"
+  # Type: Path -> Derivation
+  patchedPackagefile = file: writeText "package.json"
     (
-      builtins.toJSON (patchPackagefile sourceHashFunc file)
+      builtins.toJSON (patchPackagefile file)
     );
 
   # Description: Takes a Path to a lockfile and returns the patched version as file in the Nix store
@@ -389,7 +389,7 @@ rec {
 
         postPatch = ''
           ln -sf ${patchedLockfile (sourceHashFunc githubSourceHashMap) packageLockJson} package-lock.json
-          ln -sf ${patchedPackagefile (sourceHashFunc githubSourceHashMap) packageJson} package.json
+          ln -sf ${patchedPackagefile packageJson} package.json
         '';
 
         buildPhase = ''

--- a/tests/authentication.nix
+++ b/tests/authentication.nix
@@ -1,0 +1,39 @@
+{ nixosTest, runCommandNoCC /*npmlock2nix, testLib, symlinkJoin, runCommand, nodejs, lib*/ }:
+
+nixosTest {
+  name = "authentication";
+  nodes.machine = { ... }: {
+    services.nginx = {
+      enable = true;
+      virtualHosts.localhost = {
+        basicAuth.bob = "bobs-secret";
+        locations."= /hello.tgz".alias = runCommandNoCC "hello.tgz"
+          {
+            indexjs = ''
+              console.log("This is a private package!")
+            '';
+            passAsFile = [ "indexjs" ];
+          } ''
+          tmp=$(mktemp -d)
+          mv "$indexjsPath" "$tmp"/index.js
+          tar -C "$tmp" -czf "$out" .
+        '';
+      };
+    };
+
+    environment.etc.test.source =
+
+      };
+
+    testScript = ''
+      start_all()
+      machine.wait_for_unit("nginx.service")
+      machine.wait_for_open_port(80)
+      machine.succeed("nix-build /etc/test")
+      machine.succeed("curl http://bob:bobs-secret@localhost/hello.tgz -O")
+      machine.succeed("mkdir hello")
+      machine.succeed("tar -C hello -xvf hello.tgz")
+    '';
+  }
+
+

--- a/tests/authentication/default.nix
+++ b/tests/authentication/default.nix
@@ -1,0 +1,55 @@
+{ nixosTest, lib, path, pkgs, runCommandNoCC, npmlock2nix }:
+
+nixosTest {
+  name = "authentication";
+  nodes.machine = { lib, ... }: {
+    services.nginx = {
+      enable = true;
+      virtualHosts.localhost = {
+        # TODO: Enable
+        # basicAuth.bob = "bobs-secret";
+        locations."= /hello.tgz".alias = runCommandNoCC "hello.tgz" { } ''
+          tar -C ${./hello} -czf "$out" .
+        '';
+      };
+
+    };
+
+    # Don't attempt to use binary caches, we don't have internet
+    nix.binaryCaches = lib.mkForce [ ];
+    nix.extraOptions = ''
+      hashed-mirrors =
+      connect-timeout = 1
+    '';
+
+    environment.etc.test.source = ./src;
+
+    nix.nixPath = [ "nixpkgs=${path}" "npmlock2nix=${builtins.fetchGit ../..}" ];
+
+    virtualisation.diskSize = 2048;
+    virtualisation.memorySize = 2048;
+
+    # We need these paths to be available in the vm already since we don't have internet
+    virtualisation.additionalPaths = [
+      pkgs.nodejs-14_x
+      pkgs.nodejs-14_x.src
+      pkgs.openssl
+      pkgs.jq.dev
+      pkgs.stdenv
+      pkgs.bashInteractive.dev
+      pkgs.stdenv.shellPackage
+    ]
+    # fetchurl uses an overridden curl
+    ++ (pkgs.fetchurl { }).nativeBuildInputs;
+  };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("nginx.service")
+    machine.wait_for_open_port(80)
+    output = machine.succeed(r'nix-shell /etc/test')
+    print(output)
+  '';
+}
+
+

--- a/tests/authentication/default.nix
+++ b/tests/authentication/default.nix
@@ -7,9 +7,20 @@ nixosTest {
       enable = true;
       virtualHosts.localhost = {
         # TODO: Enable
-        # basicAuth.bob = "bobs-secret";
-        locations."= /hello.tgz".alias = runCommandNoCC "hello.tgz" { } ''
-          tar -C ${./hello} -czf "$out" .
+        locations."= /hello.tgz" = {
+          alias = runCommandNoCC "hello.tgz" { } ''
+            tar -C ${./hello} -czf "$out" .
+          '';
+          extraConfig = ''
+            auth_request /auth;
+          '';
+        };
+
+        locations."= /auth".extraConfig = ''
+          if ( $http_authorization = 'Bearer some-token' ) {
+              return 204;
+          }
+          return 401;
         '';
       };
 

--- a/tests/authentication/hello/index.js
+++ b/tests/authentication/hello/index.js
@@ -1,0 +1,1 @@
+console.log("This is a private package!")

--- a/tests/authentication/hello/package.json
+++ b/tests/authentication/hello/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "hello",
+  "version": "0.0.1",
+  "description": "",
+  "main": "index.js",
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+  }
+}

--- a/tests/authentication/src/.npmrc
+++ b/tests/authentication/src/.npmrc
@@ -1,0 +1,4 @@
+@someScope:registry=http://localhost/
+
+# Passwords
+//localhost/:_authToken=some-token

--- a/tests/authentication/src/default.nix
+++ b/tests/authentication/src/default.nix
@@ -1,0 +1,13 @@
+let
+  npmlock2nixSource = <npmlock2nix>;
+  pkgs = import <nixpkgs> { };
+  npmlock2nix = import npmlock2nixSource { inherit pkgs; };
+  lib = pkgs.lib;
+in
+npmlock2nix.shell {
+  src = ./.;
+  shellHook = ''
+    node -e 'require("@someScope/hello")'
+    exit
+  '';
+}

--- a/tests/authentication/src/package-lock.json
+++ b/tests/authentication/src/package-lock.json
@@ -1,0 +1,1 @@
+{"dependencies":{"@someScope/hello":{"integrity":"sha1-XJ75k6+tnzctMC9iKIZye15exb4=","resolved":"http://localhost/hello.tgz","version":"0.0.1"}},"lockfileVersion":1,"name":"single-dependency","requires":true,"version":"1.0.0"}

--- a/tests/authentication/src/package.json
+++ b/tests/authentication/src/package.json
@@ -1,0 +1,1 @@
+{"author":"","dependencies":{"@someScope/hello":"0.0.1"},"description":"","license":"ISC","main":"index.js","name":"single-dependency","version":"1.0.0"}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -19,4 +19,5 @@ in
   read-lockfile = callPackage ./read-lockfile { };
   shell = callPackage ./shell.nix { };
   source-hash-func = callPackage ./source-hash-func.nix { };
+  authentication = callPackage ./authentication { };
 }

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -10,7 +10,7 @@
   # Reads a given file (either drv, path or string) and returns it's sha256 hash
   hashFile = filename: builtins.hashString "sha256" (builtins.readFile filename);
 
-  noGithubHashes = (_: null);
+  noSourceOptions = { sourceHashFunc = _: null; };
 
   runTests = tests:
     let

--- a/tests/make-github-source.nix
+++ b/tests/make-github-source.nix
@@ -1,6 +1,6 @@
 { lib, npmlock2nix, testLib }:
 let
-  inherit (testLib) noGithubHashes;
+  inherit (testLib) noSourceOptions;
   i = npmlock2nix.internal;
 
   testDependency = {
@@ -12,7 +12,7 @@ in
   testSimpleCase = {
     expr =
       let
-        version = (i.makeGithubSource noGithubHashes "leftpad" testDependency).version;
+        version = (i.makeGithubSource noSourceOptions "leftpad" testDependency).version;
       in
       lib.hasPrefix "file:///nix/store" version;
     expected = true;
@@ -21,7 +21,7 @@ in
   testDropsFrom = {
     expr =
       let
-        dep = i.makeGithubSource noGithubHashes "leftpad" testDependency;
+        dep = i.makeGithubSource noSourceOptions "leftpad" testDependency;
       in
       dep ? from;
     expected = false;

--- a/tests/make-source-urls.nix
+++ b/tests/make-source-urls.nix
@@ -1,13 +1,14 @@
 { npmlock2nix, testLib }:
 testLib.runTests {
   testUrlForDependency = {
-    expr = npmlock2nix.internal.makeSourceAttrs "test" {
+    expr = npmlock2nix.internal.makeSourceAttrs { } "test" {
       resolved = "https://example.com/package.tgz";
       integrity = "sha1-hrGk3k+s4YCsVFqD8VA1I9j+0RU=";
     };
     expected = {
       url = "https://example.com/package.tgz";
       hash = "sha1-hrGk3k+s4YCsVFqD8VA1I9j+0RU=";
+      curlOpts = "";
     };
   };
 }

--- a/tests/make-source.nix
+++ b/tests/make-source.nix
@@ -1,7 +1,7 @@
 { testLib, npmlock2nix }:
 let
   i = npmlock2nix.internal;
-  f = builtins.throw "Shouldn't be called";
+  f = { sourceHashFunc = builtins.throw "Shouldn't be called"; };
 in
 testLib.runTests {
   testMakeSourceRegular = {

--- a/tests/patch-lockfile.nix
+++ b/tests/patch-lockfile.nix
@@ -1,13 +1,13 @@
 { npmlock2nix, testLib, lib }:
 let
-  inherit (testLib) noGithubHashes;
+  inherit (testLib) noSourceOptions;
 in
 testLib.runTests {
 
   testPatchDependencyHandlesGitHubRefsInRequires = {
     expr =
       let
-        libxmljsUrl = (npmlock2nix.internal.patchDependency noGithubHashes "test" {
+        libxmljsUrl = (npmlock2nix.internal.patchDependency noSourceOptions "test" {
           version = "github:tmcw/leftpad#db1442a0556c2b133627ffebf455a78a1ced64b9";
           from = "github:tmcw/leftpad#db1442a0556c2b133627ffebf455a78a1ced64b9";
           integrity = "sha512-8/UvHFG90J4O4QNRzb0jB5Ni1QuvuB7XFTLfDMQnCzAsFemF29VKnNGUESFFcSP/r5WWh/PMe0YRz90+3IqsUA==";
@@ -22,7 +22,7 @@ testLib.runTests {
   };
 
   testBundledDependenciesAreRetained = {
-    expr = npmlock2nix.internal.patchDependency noGithubHashes "test" {
+    expr = npmlock2nix.internal.patchDependency noSourceOptions "test" {
       bundled = true;
       integrity = "sha1-hrGk3k+s4YCsVFqD8VA1I9j+0RU=";
       something = "bar";
@@ -37,12 +37,12 @@ testLib.runTests {
   };
 
   testPatchLockfileWithoutDependencies = {
-    expr = (npmlock2nix.internal.patchLockfile noGithubHashes ./examples-projects/no-dependencies/package-lock.json).dependencies;
+    expr = (npmlock2nix.internal.patchLockfile noSourceOptions ./examples-projects/no-dependencies/package-lock.json).dependencies;
     expected = { };
   };
 
   testPatchDependencyDoesntDropAttributes = {
-    expr = npmlock2nix.internal.patchDependency noGithubHashes "test" {
+    expr = npmlock2nix.internal.patchDependency noSourceOptions "test" {
       a = 1;
       foo = "something";
       resolved = "https://examples.com/something.tgz";
@@ -59,7 +59,7 @@ testLib.runTests {
   };
 
   testPatchDependencyPatchesDependenciesRecursively = {
-    expr = npmlock2nix.internal.patchDependency noGithubHashes "test" {
+    expr = npmlock2nix.internal.patchDependency noSourceOptions "test" {
       a = 1;
       foo = "something";
       resolved = "https://examples.com/something.tgz";
@@ -85,7 +85,7 @@ testLib.runTests {
   testPatchLockfileTurnsUrlsIntoStorePaths = {
     expr =
       let
-        deps = (npmlock2nix.internal.patchLockfile noGithubHashes ./examples-projects/single-dependency/package-lock.json).dependencies;
+        deps = (npmlock2nix.internal.patchLockfile noSourceOptions ./examples-projects/single-dependency/package-lock.json).dependencies;
       in
       lib.count (dep: lib.hasPrefix "file:///nix/store/" dep.resolved) (lib.attrValues deps);
     expected = 1;
@@ -94,19 +94,19 @@ testLib.runTests {
   testPatchLockfileTurnsGitHubUrlsIntoStorePaths = {
     expr =
       let
-        leftpad = (npmlock2nix.internal.patchLockfile noGithubHashes ./examples-projects/github-dependency/package-lock.json).dependencies.leftpad;
+        leftpad = (npmlock2nix.internal.patchLockfile noSourceOptions ./examples-projects/github-dependency/package-lock.json).dependencies.leftpad;
       in
       lib.hasPrefix ("file://" + builtins.storeDir) leftpad.version;
     expected = true;
   };
 
   testConvertPatchedLockfileToJSON = {
-    expr = builtins.typeOf (builtins.toJSON (npmlock2nix.internal.patchLockfile noGithubHashes ./examples-projects/nested-dependencies/package-lock.json)) == "string";
+    expr = builtins.typeOf (builtins.toJSON (npmlock2nix.internal.patchLockfile noSourceOptions ./examples-projects/nested-dependencies/package-lock.json)) == "string";
     expected = true;
   };
 
   testPatchedLockFile = {
-    expr = testLib.hashFile (npmlock2nix.internal.patchedLockfile noGithubHashes ./examples-projects/nested-dependencies/package-lock.json);
+    expr = testLib.hashFile (npmlock2nix.internal.patchedLockfile noSourceOptions ./examples-projects/nested-dependencies/package-lock.json);
     expected = "980323c3a53d86ab6886f21882936cfe7c06ac633993f16431d79e3185084414";
   };
 

--- a/tests/patch-packagefile.nix
+++ b/tests/patch-packagefile.nix
@@ -1,19 +1,18 @@
 { lib, npmlock2nix, testLib }:
 let
-  inherit (testLib) noGithubHashes;
   i = npmlock2nix.internal;
 in
 (testLib.runTests {
   testTurnsGitHubRefsToWildcards = {
-    expr = (npmlock2nix.internal.patchPackagefile noGithubHashes ./examples-projects/github-dependency/package.json).dependencies.leftpad;
+    expr = (npmlock2nix.internal.patchPackagefile ./examples-projects/github-dependency/package.json).dependencies.leftpad;
     expected = "*";
   };
   testHandlesBranches = {
-    expr = (npmlock2nix.internal.patchPackagefile noGithubHashes ./examples-projects/github-dependency-branch/package.json).dependencies.leftpad;
+    expr = (npmlock2nix.internal.patchPackagefile ./examples-projects/github-dependency-branch/package.json).dependencies.leftpad;
     expected = "*";
   };
   testHandlesDevDependencies = {
-    expr = (npmlock2nix.internal.patchPackagefile noGithubHashes ./examples-projects/github-dev-dependency/package.json).devDependencies.leftpad;
+    expr = (npmlock2nix.internal.patchPackagefile ./examples-projects/github-dev-dependency/package.json).devDependencies.leftpad;
     expected = "*";
   };
 })


### PR DESCRIPTION
Implement npm registry authentication, allowing access to private registries via `.npmrc`

This PR also includes the first two commits from #151 since the same changes are needed for authentication support.

Unfortunately the NixOS VM test for authentication created in this PR can't run in GitHub Actions, but it works locally.

TODO:
- [x] Implement `.npmrc` fields `_authToken` and `_auth`
- [x] Create a basic test for `_authToken`
- [ ] Implement `.npmrc` fields `_password` and `username` (this might not be possible)
- [ ] Test a `package-lock.json` and `.npmrc` generated by npm (the current one is hand-written)
- [ ] Try to actually run `npm` with the example from the current test
- [ ] Handle environment variables in `.npmrc`, see https://stackoverflow.com/questions/53099434/using-auth-tokens-in-npmrc
- [ ] Improve the code, individual functions should be split off
- [ ] More tests, especially for the internal functions used, but also more VM tests for different authentication mechanisms
- [ ] Documentation