### PR TITLE
Add example project for linked projects

### DIFF
--- a/tests/tests-v2/examples-projects/link-packages/linked-project/.gitignore
+++ b/tests/tests-v2/examples-projects/link-packages/linked-project/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+result

--- a/tests/tests-v2/examples-projects/link-packages/linked-project/default.nix
+++ b/tests/tests-v2/examples-projects/link-packages/linked-project/default.nix
@@ -1,0 +1,6 @@
+{ pkgs ? import ../../../../../nix { } }:
+
+pkgs.npmlock2nix.v2.build {
+  src = pkgs.nix-gitignore.gitignoreSource [ "*.nix" ] ./.;
+  installPhase = "cp -r . $out";
+}

--- a/tests/tests-v2/examples-projects/link-packages/linked-project/linked.js
+++ b/tests/tests-v2/examples-projects/link-packages/linked-project/linked.js
@@ -1,0 +1,1 @@
+export default hello = "world"

--- a/tests/tests-v2/examples-projects/link-packages/linked-project/package-lock.json
+++ b/tests/tests-v2/examples-projects/link-packages/linked-project/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "linked-project",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "linked-project",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/tests/tests-v2/examples-projects/link-packages/linked-project/package.json
+++ b/tests/tests-v2/examples-projects/link-packages/linked-project/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "linked-project",
+  "version": "1.0.0",
+  "main": "linked.js",
+  "scripts": {
+    "build": "echo Nothing to build"
+  }
+}

--- a/tests/tests-v2/examples-projects/link-packages/main-project/.gitignore
+++ b/tests/tests-v2/examples-projects/link-packages/main-project/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+result

--- a/tests/tests-v2/examples-projects/link-packages/main-project/default.nix
+++ b/tests/tests-v2/examples-projects/link-packages/main-project/default.nix
@@ -1,0 +1,19 @@
+{ pkgs ? import ../../../../../nix { } }:
+
+let
+  linked-project = pkgs.callPackage ../linked-project { };
+in
+pkgs.npmlock2nix.v2.build {
+  src = pkgs.nix-gitignore.gitignoreSource [ ] ./.;
+  node_modules_attrs = {
+    postFixup = ''
+      ln -sfn ${linked-project} $out/node_modules/linked-project
+    '';
+  };
+  installPhase = ''
+    cp -r . $out
+
+    # Validate that linked project is referenced correctly
+    test -f $out/node_modules/linked-project/linked.js && echo "Project is linked correctly"
+  '';
+}

--- a/tests/tests-v2/examples-projects/link-packages/main-project/index.js
+++ b/tests/tests-v2/examples-projects/link-packages/main-project/index.js
@@ -1,0 +1,3 @@
+import defaultExport from "node_modules/linked-project";
+
+console.log(linked-project);

--- a/tests/tests-v2/examples-projects/link-packages/main-project/package-lock.json
+++ b/tests/tests-v2/examples-projects/link-packages/main-project/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "main-project",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "main-project",
+      "version": "1.0.0",
+      "dependencies": {
+        "linked-project": "file:../linked-project"
+      }
+    },
+    "../linked-project": {
+      "version": "1.0.0"
+    },
+    "node_modules/linked-project": {
+      "resolved": "../linked-project",
+      "link": true
+    }
+  },
+  "dependencies": {
+    "linked-project": {
+      "version": "file:../linked-project"
+    }
+  }
+}

--- a/tests/tests-v2/examples-projects/link-packages/main-project/package.json
+++ b/tests/tests-v2/examples-projects/link-packages/main-project/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "main-project",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "build": "echo Nothing to build"
+  },
+  "dependencies": {
+    "linked-project": "file:../linked-project"
+  }
+}


### PR DESCRIPTION
Adding example/tests on top of the change made by @zimbatm (thank you Jonas).
The example project shows how to create a build pipeline between two linked projects.

This change is critically important to be able to work with npmlock2nix in scenarios where nix is used as a build system for mono-repository.