### PR TITLE
allow using local dependencies by providing their paths

### DIFF
--- a/internal-v2.nix
+++ b/internal-v2.nix
@@ -270,7 +270,7 @@ rec {
   # URL stored in the integrity field with nix store path.
   # spec :: {version :: String, resolved :: String, integrity :: String }.
   # Type: { version :: String, resolved :: String, integrity :: String }
-  patchPackage = sourceOptions@{ sourceHashFunc, localPackages, ... }: raw_name: spec:
+  patchPackage = sourceOptions@{ sourceHashFunc, localPackages ? { }, ... }: raw_name: spec:
     assert (builtins.typeOf raw_name != "string") ->
       throw "Name of dependency ${toString raw_name} must be a string";
     assert !(spec ? resolved || (spec ? inBundle && spec.inBundle == true) || (isLocalPackage raw_name)) ->

--- a/tests/tests-v2/examples-projects/local-dependency/default.nix
+++ b/tests/tests-v2/examples-projects/local-dependency/default.nix
@@ -1,0 +1,10 @@
+{ pkgs ? import ../../../../nix { } }:
+
+pkgs.npmlock2nix.v2.node_modules {
+  src = ./.;
+  packageJson = ./package.json;
+  packageLockJson = ./package-lock.json;
+  localPackages = {
+    leftpad = ../local-leftpad;
+  };
+}

--- a/tests/tests-v2/examples-projects/local-dependency/package-lock.json
+++ b/tests/tests-v2/examples-projects/local-dependency/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "local-dependency",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "local-dependency",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "leftpad": "../local-leftpad"
+      }
+    },
+    "../local-leftpad": {
+      "version": "1.0.0",
+      "license": "ISC"
+    },
+    "node_modules/leftpad": {
+      "resolved": "../local-leftpad",
+      "link": true
+    }
+  }
+}

--- a/tests/tests-v2/examples-projects/local-dependency/package.json
+++ b/tests/tests-v2/examples-projects/local-dependency/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "local-dependency",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "leftpad": "../local-leftpad"
+  }
+}

--- a/tests/tests-v2/examples-projects/local-leftpad/package.json
+++ b/tests/tests-v2/examples-projects/local-leftpad/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "leftpad",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/tests/tests-v2/node-modules.nix
+++ b/tests/tests-v2/node-modules.nix
@@ -1,4 +1,4 @@
-{ npmlock2nix, testLib, runCommand, nodejs-16_x, nodejs-17_x, python3 }:
+{ npmlock2nix, testLib, runCommand, nodejs-16_x, nodejs-17_x, python3, lib }:
 testLib.runTests {
   testNodeModulesForEmptyDependencies = {
     expr =
@@ -161,4 +161,18 @@ testLib.runTests {
       expr = builtins.pathExists drv.outPath;
       expected = true;
     };
+
+  testLocalDependency = {
+    expr =
+      let
+        drv = npmlock2nix.v2.node_modules {
+          src = ./examples-projects/local-dependency;
+          localPackages = {
+            leftpad = ./examples-projects/local-leftpad;
+          };
+        };
+      in
+      builtins.pathExists (drv + "/node_modules/leftpad");
+    expected = true;
+  };
 }

--- a/tests/tests-v2/patch-package.nix
+++ b/tests/tests-v2/patch-package.nix
@@ -32,6 +32,9 @@ let
       require-from-string = "^2.0.2";
     };
   };
+  localLeftPadOptions = noSourceOptions // {
+    localPackages.leftpad = ./examples-projects/local-leftpad;
+  };
 in
 (testLib.runTests {
   testGhSourceRef = {
@@ -114,5 +117,16 @@ in
       in
       result ? peerDependencies;
     expected = false;
+  };
+  testPatchDepLocal = {
+    expr =
+      let
+        res = (i.patchPackage localLeftPadOptions "node_modules/leftpad" {
+          resolved = "../leftpad";
+          link = true;
+        });
+      in
+      [ (lib.hasPrefix "file:///nix/store" res.resolved) (res.integrity == null) ];
+    expected = [ true true ];
   };
 })


### PR DESCRIPTION
Provide a solution for #98

With this patch, given a package.json with

```json
"dependencies": {
    "foo": "file:../foo"
},
```

you can tell npmlock2nix to resolve the local dependency using

```nix
npmlock2nix.v2.node_modules {
  src = ./.;
  localPackages = {
    "foo" = ../foo;
  };
};
```